### PR TITLE
[Feature] 컴포넌트 명  변경 및  gql 쿼리 분리

### DIFF
--- a/front-end/mona_front/src/hooks/useGetRestaurants.ts
+++ b/front-end/mona_front/src/hooks/useGetRestaurants.ts
@@ -1,4 +1,5 @@
 import { gql, useQuery } from '@apollo/client';
+import { RestaurantListInfo } from '../models/restaurant.model';
 
 const GET_RESTAURANTS = gql`
   query Restaurants($roadName: String!, $limit: Int!, $skipNumber: Int!) {
@@ -17,17 +18,9 @@ const GET_RESTAURANTS = gql`
   }
 `;
 
-const GET_REVERSE_GEOCODING = gql`
-  query GetLocation($x: Float!, $y: Float!) {
-    reverseGeocoding(inputReverseGeocoding: { x: $x, y: $y }) {
-      results
-    }
-  }
-`;
-
 export const useGetRestaurant = (
   roadName: string,
-  callback: (data: any) => void,
+  callback: (data: RestaurantListInfo[]) => void,
   skipNumber = 0,
   limit = 10,
 ) => {

--- a/front-end/mona_front/src/hooks/useGetRestaurants.ts
+++ b/front-end/mona_front/src/hooks/useGetRestaurants.ts
@@ -1,0 +1,50 @@
+import { gql, useQuery } from '@apollo/client';
+
+const GET_RESTAURANTS = gql`
+  query Restaurants($roadName: String!, $limit: Int!, $skipNumber: Int!) {
+    restaurants(
+      inputData: { query: $roadName, limit: $limit, skip: $skipNumber }
+    ) {
+      restaurantName
+      restaurantId
+      restaurantDescription
+      restaurantCategory
+      restaurantAddress
+      restaurantRate
+      restaurantCongestion
+      restaurantImage
+    }
+  }
+`;
+
+const GET_REVERSE_GEOCODING = gql`
+  query GetLocation($x: Float!, $y: Float!) {
+    reverseGeocoding(inputReverseGeocoding: { x: $x, y: $y }) {
+      results
+    }
+  }
+`;
+
+export const useGetRestaurant = (
+  roadName: string,
+  callback: (data: any) => void,
+  skipNumber = 0,
+  limit = 10,
+) => {
+  const { loading, error, data, refetch } = useQuery(GET_RESTAURANTS, {
+    variables: {
+      roadName,
+      skipNumber,
+      limit,
+    },
+    onCompleted: data => {
+      callback(data.restaurants);
+    },
+  });
+  return {
+    loading,
+    error,
+    data,
+    refetch,
+  };
+};

--- a/front-end/mona_front/src/hooks/useGetReverseGeoCoding.ts
+++ b/front-end/mona_front/src/hooks/useGetReverseGeoCoding.ts
@@ -1,0 +1,31 @@
+import { gql, useQuery } from '@apollo/client';
+
+const GET_REVERSE_GEOCODING = gql`
+  query GetLocation($x: Float!, $y: Float!) {
+    reverseGeocoding(inputReverseGeocoding: { x: $x, y: $y }) {
+      results
+    }
+  }
+`;
+
+export const useGetReverseGeoCoding = (
+  x: number,
+  y: number,
+  skipNumber = 0,
+  limit = 10,
+) => {
+  const { loading, error, data, refetch, networkStatus } = useQuery(
+    GET_REVERSE_GEOCODING,
+    {
+      variables: { x, y, skipNumber, limit },
+      notifyOnNetworkStatusChange: true,
+    },
+  );
+  return {
+    loading,
+    error,
+    data,
+    refetch,
+    networkStatus,
+  };
+};

--- a/front-end/mona_front/src/pages/Home/components/Home.tsx
+++ b/front-end/mona_front/src/pages/Home/components/Home.tsx
@@ -13,30 +13,8 @@ import {
 import { CoordsResultItem } from '../../../models/coords.model';
 import Loader from '../../../components/common/Loader';
 import ScrollObserverContainer from '../../../components/common/ScrollObserverContainer';
-
-const GET_RESTAURANTS = gql`
-  query Restaurants($roadName: String!, $limit: Int!, $skipNumber: Int!) {
-    restaurants(
-      inputData: { query: $roadName, limit: $limit, skip: $skipNumber }
-    ) {
-      restaurantName
-      restaurantId
-      restaurantDescription
-      restaurantCategory
-      restaurantAddress
-      restaurantRate
-      restaurantCongestion
-      restaurantImage
-    }
-  }
-`;
-const GET_REVERSE_GEOCODING = gql`
-  query GetLocation($x: Float!, $y: Float!) {
-    reverseGeocoding(inputReverseGeocoding: { x: $x, y: $y }) {
-      results
-    }
-  }
-`;
+import { useGetRestaurant } from '../../../hooks/useGetRestaurants';
+import { useGetReverseGeoCoding } from '../../../hooks/useGetReverseGeoCoding';
 
 const Title = styled(Typography)`
   padding: 40px 0 16px;
@@ -57,7 +35,7 @@ const findLand = (coordItems: CoordsResultItem[]) => {
   return coordItems.find(item => item.land);
 };
 
-const CardList = () => {
+const Home = () => {
   const [restaurantList, setRestaurantList] = useState<RestaurantListInfo[]>(
     [],
   );
@@ -66,25 +44,13 @@ const CardList = () => {
   const addressData = location.state
     ? (location.state as AddressData)
     : DEFAULT_ADDRESS_DATA;
-  const { loading, error, data, refetch } = useQuery(GET_RESTAURANTS, {
-    variables: {
-      roadName: addressData.roadname,
-      skipNumber: 0,
-      limit: 10,
-    },
-    onCompleted: data => {
-      setRestaurantList(data.restaurants);
-    },
-  });
+  const { loading, error, data, refetch } = useGetRestaurant(
+    addressData.roadname,
+    setRestaurantList,
+  );
 
   const { refetch: locationRefetch, networkStatus: locationNetWorkStatus } =
-    useQuery(GET_REVERSE_GEOCODING, {
-      variables: {
-        x: 127.048542,
-        y: 37.519995,
-      },
-      notifyOnNetworkStatusChange: true,
-    });
+    useGetReverseGeoCoding(127.048542, 37.519995);
 
   useEffect(() => {
     if ('geolocation' in navigator) {
@@ -160,4 +126,4 @@ const CardList = () => {
   );
 };
 
-export default CardList;
+export default Home;

--- a/front-end/mona_front/src/pages/Home/index.tsx
+++ b/front-end/mona_front/src/pages/Home/index.tsx
@@ -1,3 +1,3 @@
-import CardList from './components/CardList';
+import Home from './components/Home';
 
-export default CardList;
+export default Home;


### PR DESCRIPTION
gql쿼리가 Home에 계속 붙어 있는게 영 보기 싫어서 일단 훅으로 떼냈어요.
다만 refetch를 다시 보내고 난 후는 어케 분리하기가 좀 애매하네요.. 🤔 .. 
컴포넌트 명도 CardList -> Home으로 변경했습니다.